### PR TITLE
raise MAX_CHROM_NAME_LEN

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -29,7 +29,7 @@ int pg_argc = 0;
 
 PlatformProfile *tech;
 
-#define MAX_CHROM_NAME_LEN 64
+#define MAX_CHROM_NAME_LEN 256
 static struct { char chrom_name[MAX_CHROM_NAME_LEN]; } *chroms;
 
 char *chrom_lookup(const chrom_t chrom)


### PR DESCRIPTION
Any reason why MAX_CHROM_NAME_LEN is set to 64? It's so low that it causes a segfault on some of my long-headered FASTA files. increasing this constant fixed the problem.