### PR TITLE
Increase array size to allow longer FASTQ read names

### DIFF
--- a/include/samrecord.h
+++ b/include/samrecord.h
@@ -9,7 +9,7 @@
 typedef struct fastq_record {
 	bc_t bc;
 	unsigned short rlen;
-	char id[100];
+	char id[150];
 	char read[MAX_READ_LEN+2];  // +2 for newline and null-term
 	char qual[MAX_READ_LEN+2];
 } FASTQRecord;


### PR DESCRIPTION
I run into an issue where the barcode got truncated due to the read name being longer than 100 characters. This is PR increases the array size to 150. 