### PR TITLE
Create create_source_release.yml

### DIFF
--- a/.github/workflows/create_source_release.yml
+++ b/.github/workflows/create_source_release.yml
@@ -28,7 +28,7 @@ jobs:
             cp -r "$PWD" "/tmp/$PT_RELEASE_NAME"
             mv "/tmp/$PT_RELEASE_NAME" .
             # Cleanup
-            rm -r "$PT_RELEASE_NAME"/{.azure_pipelines,.circleci,.jenkins}
+            rm -rf "$PT_RELEASE_NAME"/{.azure_pipelines,.circleci,.jenkins}
             find "$PT_RELEASE_NAME" -name '.git*' -exec rm -rv {} \; || true
             # Create archive
             tar -czf "$PT_RELEASE_FILE" "$PT_RELEASE_NAME"

--- a/.github/workflows/create_source_release.yml
+++ b/.github/workflows/create_source_release.yml
@@ -1,0 +1,40 @@
+name: Create Release
+
+on:
+  push:
+    tags: ['v*']
+    branches: [master]
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Set filenames
+        run: |
+          tag_or_branch="${GITHUB_REF#refs/tags/}"
+          tag_or_branch="${tag_or_branch#refs/heads/}"
+          echo "PT_RELEASE_NAME=ema-$tag_or_branch" >> "$GITHUB_ENV"
+          echo "PT_RELEASE_FILE=ema-$tag_or_branch.tar.gz" >> "$GITHUB_ENV"
+      - name: Create source distribution
+        run: |
+            # Create new folder with specified name so extracting the archive yields that
+            rm -rf "/tmp/$PT_RELEASE_NAME"
+            cp -r "$PWD" "/tmp/$PT_RELEASE_NAME"
+            mv "/tmp/$PT_RELEASE_NAME" .
+            # Cleanup
+            rm -r "$PT_RELEASE_NAME"/{.azure_pipelines,.circleci,.jenkins}
+            find "$PT_RELEASE_NAME" -name '.git*' -exec rm -rv {} \; || true
+            # Create archive
+            tar -czf "$PT_RELEASE_FILE" "$PT_RELEASE_NAME"
+            echo "Created source archive $PT_RELEASE_FILE with content: $(ls -a "$PT_RELEASE_NAME")"
+      - name: Upload source distribution
+        if: ${{ github.event_name == 'release' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{env.PT_RELEASE_FILE}}


### PR DESCRIPTION
This is a github workflow taken from https://github.com/pytorch/pytorch/pull/63022 that on tagging a new release, uploads the full source tarball, including the bwa submodule. The reasoning for this is that ema requires the bwa submodule to compile and submodules are not included in releases, so getting the conda recipe to build correctly is frustrating. The other alternative is to un-link bwa as a submodule and instead include it as a hardcoded folder, which doesn't seem like a great longterm solution. 