### PR TITLE
Enable mapping TELL-Seq and DBS linked reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ align: choose best alignments based on barcodes
   -o <SAM file>: output SAM file [stdout]
   -R <RG string>: full read group string (e.g. '@RG\tID:foo\tSM:bar') [none]
   -d: apply fragment read density optimization [off]
-  -p <platform>: sequencing platform (one of '10x', 'tru', 'cpt', 'haplotag', 'dbs') [10x]
+  -p <platform>: sequencing platform (one of '10x', 'tru', 'cpt', 'haplotag', 'dbs', 'tellseq') [10x]
   -i <index>: index to follow 'BX' tag in SAM output [1]
   -t <threads>: set number of threads [1]
   all other arguments (only for -x): list of all preprocessed inputs
@@ -157,8 +157,36 @@ sambamba merge -t 40 -p ema_final.bam output_dir/*.bam
 Now you should have a single, sorted, duplicate-marked BAM `ema_final.bam`.
 
 ### Other sequencing platforms
+EMA can also be run using data from other linked-read or sequencing platforms than 10x Genomics. Other platforms are selected using the flag `-p <platfrom>`. Available platforms and their flags specifications are:
 
-**DBS**
+- [TELL-seq](#tell-seq): `tellseq`
+- [Droplet Barcode Sequencing (DBS)](#dbs): `dbs`
+- [CPT-seq](#cpt-seqtruseq-slr): `cpt`
+- [TruSeq Synthetic Long Reads (SLR)](#cpt-seqtruseq-slr): `tru`
+
+#### TELL-Seq
+
+The TELL-seq linked-read platform is commercially available from [Universal Sequencing](https://www.universalsequencing.com/) and was presented in [Chen et al. 2020 GenomeRes](https://doi.org/10.1101/gr.260380.119). The platform uses a 18 bp semi-degenerate barcode. The FASTQs can for example be preprocess using the Universal Sequencing TELL-Read pipeline to generate barcodes tagged FASTQs as below where the barcode is added after the read name as below 
+
+```
+@A00741:47:HCM53DRXX:1:1101:18159:7326:TTATTTAATCTTAGTCGT 1:N:0:1
+TTATTTAATCTTAGTCGTCCTGGCTAATTTTTTTGTATTTTTATTAGATACGGGATTTCTCCATGTTGGCTTGGCGGGTCTCAAACTCTTGACCTTAGGTGATCTGCCTGCCTCAGCCTCCCAAAGTGCTGGGATTACCGGCGTGAGCCACCGCACCCAGCCTA
++
+,FFFFFFFFF:FFF::FF,FFFFFFFFFF,FFF:F,F::,FFFF,F,F,FF,,FFFFFFFFFF,,FF:F:FF,F:F,,FFFFFFFF:FFFFFFFF:F,:FFFFFF:FFF:FF,FFFFFFFFFFFF:,::F,FFFF:FFFF,FF,FFFFFF:,,FFFFFFFFFFF
+```
+
+Note that these FASTQs need to be sorted by barcode before using `ema align`.
+
+EMA also supports TELL-seq data provided in the `longranger basic` format, e.g. BX tagged FASTQs as below
+
+```
+@A00741:47:HCM53DRXX:1:1101:18159:7326 BX:Z:TTATTTAATCTTAGTCGT
+TTATTTAATCTTAGTCGTCCTGGCTAATTTTTTTGTATTTTTATTAGATACGGGATTTCTCCATGTTGGCTTGGCGGGTCTCAAACTCTTGACCTTAGGTGATCTGCCTGCCTCAGCCTCCCAAAGTGCTGGGATTACCGGCGTGAGCCACCGCACCCAGCCTA
++
+,FFFFFFFFF:FFF::FF,FFFFFFFFFF,FFF:F,F::,FFFF,F,F,FF,,FFFFFFFFFF,,FF:F:FF,F:F,,FFFFFFFF:FFFFFFFF:F,:FFFFFF:FFF:FF,FFFFFFFFFFFF:,::F,FFFF:FFFF,FF,FFFFFF:,,FFFFFFFFFFF
+```
+
+#### DBS
 
 EMA can run using linked reads generated using the method presented in [Redin et al. 2019 SciRep](https://doi.org/10.1038/s41598-019-54446-x), commonly referred to as Droplet Barcode Sequencing (DBS). For running `ema align` with DBS linked-read the FASTQs must have the 20 base barcode present in the read header, similar to output from `longranger basic`. Here is an example FASTQ entry with the barcode `CTTGGTCATTCATACAGTCC`. 
 
@@ -169,9 +197,7 @@ CAGTGGGAGCCCTGACCTTGTTTTTCTGTAAGTAGACGGTCCATCTAGGGGTGATGGGAGAAAGTGACAGATCATCAGGC
 F,FF,FFFFFFFFFFFFFFFFFFFFFFFFFFFF,FFFFFFFFF:FFFFFFFFFF:FFFFF,FFFFFFFFFFFFFFFF:FF::FFF,FFFFFFF,FFFFFFFFFF,FFFFFF:FFFFFFFFFFFFFFFFFFFFFFFF:FFF:F:FFFFFFFF
 ```
 
-The `-p dbs` flag must be set for DBS linked reads.
-
-**CPT-seq/TruSeq SLR**
+#### CPT-seq/TruSeq SLR
 
 Instructions for preprocessing and running EMA on data from CPT-seq and TruSeq Synthetic Long Reads can be found [here](https://github.com/arshajii/ema-paper-data/blob/master/experiments.ipynb).
 

--- a/README.md
+++ b/README.md
@@ -165,9 +165,11 @@ EMA can also be run using data from other linked-read or sequencing platforms th
 - [CPT-seq](#cpt-seqtruseq-slr): `cpt`
 - [TruSeq Synthetic Long Reads (SLR)](#cpt-seqtruseq-slr): `tru`
 
+For preprocessing with subcommands `count` and `preproc`, only 10x Genomics and Haplotagging reads are enabled a the moment.
+
 #### Haplotagging
 
-The haplotagging method for generating long reads was presented in [Meier et al. 2021](https://doi.org/10.1073/pnas.2015005118). The platform uses a 16 bp barcode. The `ema` subcommands `count` and `preproc` for preprocessing is also enable for haplotagging reads. 
+The haplotagging method for generating long reads was presented in [Meier et al. 2021 PNAS](https://doi.org/10.1073/pnas.2015005118). The platform uses a 16 bp barcode. See the [Haplotagging note](#haplotagging-note) above for more information about using these reads.
 
 #### TELL-Seq
 

--- a/README.md
+++ b/README.md
@@ -159,10 +159,15 @@ Now you should have a single, sorted, duplicate-marked BAM `ema_final.bam`.
 ### Other sequencing platforms
 EMA can also be run using data from other linked-read or sequencing platforms than 10x Genomics. Other platforms are selected using the flag `-p <platfrom>`. Available platforms and their flags specifications are:
 
+- [Haplotagging](#haplotagging): `haplotag`
 - [TELL-seq](#tell-seq): `tellseq`
 - [Droplet Barcode Sequencing (DBS)](#dbs): `dbs`
 - [CPT-seq](#cpt-seqtruseq-slr): `cpt`
 - [TruSeq Synthetic Long Reads (SLR)](#cpt-seqtruseq-slr): `tru`
+
+#### Haplotagging
+
+The haplotagging method for generating long reads was presented in [Meier et al. 2021](https://doi.org/10.1073/pnas.2015005118). The platform uses a 16 bp barcode. The `ema` subcommands `count` and `preproc` for preprocessing is also enable for haplotagging reads. 
 
 #### TELL-Seq
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ align: choose best alignments based on barcodes
   -o <SAM file>: output SAM file [stdout]
   -R <RG string>: full read group string (e.g. '@RG\tID:foo\tSM:bar') [none]
   -d: apply fragment read density optimization [off]
-  -p <platform>: sequencing platform (one of '10x', 'tru', 'cpt', 'haplotag') [10x]
+  -p <platform>: sequencing platform (one of '10x', 'tru', 'cpt', 'haplotag', 'dbs') [10x]
   -i <index>: index to follow 'BX' tag in SAM output [1]
   -t <threads>: set number of threads [1]
   all other arguments (only for -x): list of all preprocessed inputs
@@ -157,7 +157,23 @@ sambamba merge -t 40 -p ema_final.bam output_dir/*.bam
 Now you should have a single, sorted, duplicate-marked BAM `ema_final.bam`.
 
 ### Other sequencing platforms
-Instructions for preprocessing and running EMA on data from other sequencing platforms can be found [here](https://github.com/arshajii/ema-paper-data/blob/master/experiments.ipynb).
+
+**DBS**
+
+EMA can run using linked reads generated using the method presented in [Redin et al. 2019 SciRep](https://doi.org/10.1038/s41598-019-54446-x), commonly referred to as Droplet Barcode Sequencing (DBS). For running `ema align` with DBS linked-read the FASTQs must have the 20 base barcode present in the read header, similar to output from `longranger basic`. Here is an example FASTQ entry with the barcode `CTTGGTCATTCATACAGTCC`. 
+
+```
+@A00621:130:HN5HWDSXX:4:1103:8639:28573 BX:Z:CTTGGTCATTCATACAGTCC
+CAGTGGGAGCCCTGACCTTGTTTTTCTGTAAGTAGACGGTCCATCTAGGGGTGATGGGAGAAAGTGACAGATCATCAGGCATTGGATTCTCCTAAGGAGGGTGCAATGTAGATCCCTCGCGTGCAGAACTCAATGTAGGGTTCATGCTCCC
++
+F,FF,FFFFFFFFFFFFFFFFFFFFFFFFFFFF,FFFFFFFFF:FFFFFFFFFF:FFFFF,FFFFFFFFFFFFFFFF:FF::FFF,FFFFFFF,FFFFFFFFFF,FFFFFF:FFFFFFFFFFFFFFFFFFFFFFFF:FFF:F:FFFFFFFF
+```
+
+The `-p dbs` flag must be set for DBS linked reads.
+
+**CPT-seq/TruSeq SLR**
+
+Instructions for preprocessing and running EMA on data from CPT-seq and TruSeq Synthetic Long Reads can be found [here](https://github.com/arshajii/ema-paper-data/blob/master/experiments.ipynb).
 
 ### Output
 EMA outputs a standard SAM file with several additional tags:

--- a/include/align.h
+++ b/include/align.h
@@ -56,8 +56,8 @@ int is_pair_relaxed(struct sam_record *r1, struct sam_record *r2);
 #define MAX_CLOUDS_PER_BC_LARGE 10000000
 
 /* lengths */
-#define BC_LEN     16
-#define MATE1_TRIM  7
+extern int BC_LEN;
+extern int MATE1_TRIM;
 
 #define MIN_READ_LEN (BC_LEN + MATE1_TRIM + 1)
 #define MAX_READ_LEN 200

--- a/include/align.h
+++ b/include/align.h
@@ -57,9 +57,7 @@ int is_pair_relaxed(struct sam_record *r1, struct sam_record *r2);
 
 /* lengths */
 extern int BC_LEN;
-extern int MATE1_TRIM;
 
-#define MIN_READ_LEN (BC_LEN + MATE1_TRIM + 1)
 #define MAX_READ_LEN 200
 #define MAX_ID_LEN   100
 

--- a/include/techs.h
+++ b/include/techs.h
@@ -12,6 +12,7 @@ typedef struct {
 
 	bc_extract_routine_t extract_bc;
 	int many_clouds;
+	uint32_t bc_len;
 	uint32_t dist_thresh;
 	double error_rate;
 

--- a/include/util.h
+++ b/include/util.h
@@ -18,7 +18,7 @@
 
 #define IS_ACGT(c) ((c) == 'A' || (c) == 'C' || (c) == 'G' || (c) == 'T')
 
-typedef uint32_t bc_t;
+typedef uint64_t bc_t;
 typedef uint32_t chrom_t;
 
 void copy_until_space(char *dest, char **src);

--- a/src/main.c
+++ b/src/main.c
@@ -27,6 +27,7 @@ char *bx_index = "1";
 char **pg_argv = NULL;
 int pg_argc = 0;
 
+int BC_LEN;
 PlatformProfile *tech;
 
 #define MAX_CHROM_NAME_LEN 256
@@ -105,8 +106,8 @@ static void print_help_and_exit(const char *argv0, int error)
 	P("  -o <SAM file>: output SAM file [stdout]\n");
 	P("  -R <RG string>: full read group string (e.g. '@RG\\tID:foo\\tSM:bar') [none]\n");
 	P("  -d: apply fragment read density optimization [off]\n");
-	P("  -p <platform>: sequencing platform (one of 'haplotag', '10x', 'tru', 'cpt') [10x]\n");
-	P("  -i <index>: index to follow 'BX' tag in SAM output [1]\n");
+	P("  -p <platform>: sequencing platform (one of '10x', 'tru', 'haplotag', 'dbs', 'cpt') [10x]\n");
+	P("  -i <index>: index to follow 'BX' tag in SAM output [1]");
 	P("  -t <threads>: set number of threads [1]\n");
 	P("  all other arguments (only for -x): list of all preprocessed inputs\n");
 	P("\n");
@@ -321,6 +322,7 @@ int main(const int argc, char *argv[])
 		FILE *fq2_file = NULL;
 		FILE *fqx_file = NULL;
 		FILE *out_file = (out == NULL ? stdout : fopen(out, "w"));
+		BC_LEN = tech->bc_len;
 
 		if (!out_file) {
 			IOERROR(out);

--- a/src/samrecord.c
+++ b/src/samrecord.c
@@ -235,8 +235,8 @@ void print_sam_record(SAMRecord *rec,
 	}
 
 	// tags
-	char bc_str[BC_LEN + 1];
-	memset( bc_str, 0, (BC_LEN + 1)*sizeof(char) );
+	char *bc_str = safe_calloc(BC_LEN + 1, sizeof *bc_str);
+    memset(bc_str, 0, BC_LEN + 1);
 	if (is_haplotag)
 	{
 		decode_bc(bc, bc_str, 1);

--- a/src/samrecord.c
+++ b/src/samrecord.c
@@ -235,9 +235,10 @@ void print_sam_record(SAMRecord *rec,
 	}
 
 	// tags
+	char bc_str[BC_LEN + 1];
+	memset( bc_str, 0, (BC_LEN + 1)*sizeof(char) );
 	if (is_haplotag)
 	{
-		char bc_str[13] = {0};
 		decode_bc(bc, bc_str, 1);
 		if (rec != NULL) {
 			fprintf(out, "\tNM:i:%d\tBX:Z:%s\tXG:f:%.5g\tMI:i:%d\tXF:i:%d", r->edit_dist, bc_str, gamma, cloud->id, cloud->bad);
@@ -246,8 +247,7 @@ void print_sam_record(SAMRecord *rec,
 		}
 	}
 	else
-	{
-		char bc_str[BC_LEN + 1] = {0};
+	{		
 		decode_bc(bc, bc_str, 0);
 		if (rec != NULL) {
 			fprintf(out, "\tNM:i:%d\tBX:Z:%s-%s\tXG:f:%.5g\tMI:i:%d\tXF:i:%d", r->edit_dist, bc_str, bx_index, gamma, cloud->id, cloud->bad);

--- a/src/techs.c
+++ b/src/techs.c
@@ -28,6 +28,32 @@ static bc_t extract_bc_10x(FASTQRecord *rec)
 	return encode_bc(&bc_str[1], 0);
 }
 
+
+static bc_t extract_bc_tellseq(FASTQRecord *rec)
+{
+	// Get text after whitespace	  
+	char *space = strchr(rec->id, ' ');
+	if (space != NULL) {
+		// If startswith BX:Z: is in longranger basic format
+		if (strncmp(" BX:Z:", space, 6) == 0) {
+			char *bc_str = strrchr(space, ':');
+			*space = '\0';
+			assert(bc_str != NULL);
+			*bc_str = '\0';
+			return encode_bc(&bc_str[1], 0);
+		}
+
+		// If not, remove text
+		*space = '\0';
+	} 
+	
+	// Take string after final ':' as barcode
+	char *bc_str = strrchr(rec->id, ':');
+	assert(bc_str != NULL);
+	*bc_str = '\0';
+	return encode_bc(&bc_str[1], 0);
+}
+
 static bc_t extract_bc_truseq(FASTQRecord *rec)
 {
 	char *bc_str = rec->id[0] == '@' ? &(rec->id)[1] : rec->id;
@@ -45,6 +71,7 @@ static bc_t extract_bc_cptseq(FASTQRecord *rec)
 static PlatformProfile profiles[] = {
 	{.name = "haplotag",
 	 .extract_bc = extract_bc_haplotag,
+	 .bc_len = 12,
 	 .many_clouds = 0,
 	 .dist_thresh = 50000,
 	 .error_rate = 0.001,
@@ -81,6 +108,15 @@ static PlatformProfile profiles[] = {
 	{.name = "dbs",
 	 .extract_bc = extract_bc_10x,
 	 .bc_len = 20,
+	 .many_clouds = 0,
+	 .dist_thresh = 50000,
+	 .error_rate = 0.001,
+	 .n_density_probs = 4,
+	 .density_probs = {0.6, 0.05, 0.2, 0.01}},
+	
+	{.name = "tellseq",
+	 .extract_bc = extract_bc_tellseq,
+	 .bc_len = 18,
 	 .many_clouds = 0,
 	 .dist_thresh = 50000,
 	 .error_rate = 0.001,

--- a/src/techs.c
+++ b/src/techs.c
@@ -53,6 +53,7 @@ static PlatformProfile profiles[] = {
 	
 	{.name = "10x",
 	 .extract_bc = extract_bc_10x,
+	 .bc_len = 16,
 	 .many_clouds = 0,
 	 .dist_thresh = 50000,
 	 .error_rate = 0.001,
@@ -61,6 +62,7 @@ static PlatformProfile profiles[] = {
 
 	{.name = "tru",
 	 .extract_bc = extract_bc_truseq,
+	 .bc_len = 0,
 	 .many_clouds = 1,
 	 .dist_thresh = 15000,
 	 .error_rate = 0.001,
@@ -69,12 +71,22 @@ static PlatformProfile profiles[] = {
 
 	{.name = "cpt",
 	 .extract_bc = extract_bc_cptseq,
+	 .bc_len = 0,
 	 .many_clouds = 1,
 	 .dist_thresh = 3500,
 	 .error_rate = 0.01,
 	 .n_density_probs = 9,
 	 .density_probs = {0.6, 0.01, 0.15, 0.001, 0.05, 0.001, 0.02, 0.001, 0.01}},
 
+	{.name = "dbs",
+	 .extract_bc = extract_bc_10x,
+	 .bc_len = 20,
+	 .many_clouds = 0,
+	 .dist_thresh = 50000,
+	 .error_rate = 0.001,
+	 .n_density_probs = 4,
+	 .density_probs = {0.6, 0.05, 0.2, 0.01}},
+	
 	{.name = NULL},
 };
 


### PR DESCRIPTION
This PR extends the `ema align` tool  too allow mapping of both TELL-Seq and DBS linked reads. 